### PR TITLE
Setting python interpreter for selinux

### DIFF
--- a/tasks/section_1/cis_1.6.x.yml
+++ b/tasks/section_1/cis_1.6.x.yml
@@ -35,10 +35,12 @@
 - name: |
     "1.6.1.3 | PATCH | Ensure SELinux policy is configured
      1.6.1.4 | PATCH | Ensure the SELinux state is enforcing or permissive"
-  selinux:
+  ansible.posix.selinux:
       conf: /etc/selinux/config
       policy: "{{ amazon2cis_selinux_pol }}"
       state: "{{ amazon2cis_selinux_state }}"
+  vars:
+      ansible_python_interpreter: /bin/python
   when:
       - not amazon2cis_selinux_disable
       - amazon2cis_rule_1_6_1_3
@@ -52,10 +54,12 @@
       - selinux
 
 - name: "1.6.1.5 | PATCH | Ensure the SELinux state is enforcing"
-  selinux:
+  ansible.posix.selinux:
       conf: /etc/selinux/config
       policy: "{{ amazon2cis_selinux_pol }}"
       state: enforcing
+  vars:
+      ansible_python_interpreter: /bin/python
   when:
       - not amazon2cis_selinux_disable
       - not amazon2cis_selinux_state == "permissive"

--- a/tasks/section_1/cis_1.6.x.yml
+++ b/tasks/section_1/cis_1.6.x.yml
@@ -40,7 +40,7 @@
       policy: "{{ amazon2cis_selinux_pol }}"
       state: "{{ amazon2cis_selinux_state }}"
   vars:
-      ansible_python_interpreter: /bin/python
+      ansible_python_interpreter: "{{ python2_bin }}"
   when:
       - not amazon2cis_selinux_disable
       - amazon2cis_rule_1_6_1_3
@@ -59,7 +59,7 @@
       policy: "{{ amazon2cis_selinux_pol }}"
       state: enforcing
   vars:
-      ansible_python_interpreter: /bin/python
+      ansible_python_interpreter: "{{ python2_bin }}"
   when:
       - not amazon2cis_selinux_disable
       - not amazon2cis_selinux_state == "permissive"


### PR DESCRIPTION
Signed-off-by: andrew-aiken <aaiken@kill.buzz>

**Overall Review of Changes:**
Adding `ansible_python_interpreter = /bin/python` on all tasks that us ansible.posix.selinux.

Updated on:
- 1.6.1.3-4
- 1.6.1.5

**Issue Fixes:**
Changed python interpreter to be used, uses python3.7 by default, python library `libselinux-python` does not exist for the version.

```
FAILED! => {"changed": false, "msg": "Failed to import the required Python library (libselinux-python) on ip-10-270-30-100.us-north-1.compute.internal's Python /usr/bin/python3.7. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
```


**How has this been tested?:**
 Tested using packer on amazon linux 2 ecs optimized.

