### PR TITLE
updated the when on 1.1.3-1.1.5

### DIFF
--- a/tasks/section_1/cis_1.1.x.yml
+++ b/tasks/section_1/cis_1.1.x.yml
@@ -33,10 +33,11 @@
   loop_control:
       label: "{{ item.device }}"
   when:
+      - item.mount == "/tmp"
       - amazon2cis_tmp_svc
-      - amazon2cis_rule_1_1_3
-      - amazon2cis_rule_1_1_4
-      - amazon2cis_rule_1_1_5
+      - amazon2cis_rule_1_1_3 or
+        amazon2cis_rule_1_1_4 or
+        amazon2cis_rule_1_1_5
   tags:
       - level1
       - automated


### PR DESCRIPTION
Signed-off-by: George Nalen <georgen@mindpointgroup.com>

**Overall Review of Changes:**
Fixed the when on 1.1.3-1.1.5 to only use the /tmp item.mount info

**Issue Fixes:**
N/A

**Enhancements:**
N/A

**How has this been tested?:**
Locally

