### PR TITLE
Patch 5.4.2 to ensure account module using pam_faillock.so setup

### DIFF
--- a/tasks/section_5/cis_5.4.x.yml
+++ b/tasks/section_5/cis_5.4.x.yml
@@ -58,6 +58,17 @@
         with_items:
             - "system-auth"
             - "password-auth"
+    
+      - name: "5.4.2 | PATCH | Ensure lockout for failed password attempts is configured | Activate deny count and unlock times to failed password"
+        lineinfile:
+            path: /etc/pam.d/{{ item }}
+            line: "account     required      pam_faillock.so"
+            insertbefore: '^#?account ?'
+            firstmatch: true
+            regexp: '^\s*account\s+required\s+pam_faillock.so\s*'
+        with_items:
+            - "system-auth"
+            - "password-auth"
 
       - name: "5.4.3 | PATCH | Ensure password hashing algorithm is SHA-512 | add sha512 settings"
         lineinfile:


### PR DESCRIPTION
Signed-off-by: Tony Ng <ngkokhong.tony@gmail.com>

**Overall Review of Changes:**
According to CIS AL2 Benchmark v2.0.0, for rule 5.4.2, the following line should be configured for system-auth :
`/etc/pam.d/system-auth:account        required         pam_faillock.so`

and similiarly for password-auth files :

`/etc/pam.d/spassword-auth:account        required         pam_faillock.so`

However, upon turning on Ansible rule for 5.4.2, the above 2 lines are not seen. 

**Issue Fixes:**
This PR is to add the lines above in the files. It also makes sure the line is positioned on the first line under the account module for each file, as mentioned in the benchmark report.

**How has this been tested?:**
Tested with our STG environment machines and the result shows the expected here:

/etc/pam.d/spassword-auth:account:
<img width="691" alt="password-auth" src="https://user-images.githubusercontent.com/16837659/205615544-ee539e80-eb28-41a2-b13a-6b8b0efbb91f.png">

/etc/pam.d/system-auth:account :
<img width="705" alt="system-auth" src="https://user-images.githubusercontent.com/16837659/205615570-f39ec5c9-9090-435a-8ea4-447dc219a0df.png">
