### PR TITLE
Add handlers for CIS 1.1.12 & 1.1.18

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,6 +13,16 @@
   args:
       warn: false
 
+- name: remount var_tmp
+  command: mount -o remount /var/tmp
+  args:
+      warn: false
+
+- name: remount home
+  command: mount -o remount /home
+  args:
+      warn: false
+
 - name: systemd daemon reload
   systemd:
       daemon_reload: true


### PR DESCRIPTION
When conforming to CIS 1.1.17 (AUDIT | Ensure separate partition exists for /home) and CIS 1.1.11 (AUDIT | Ensure separate partition exists for /var/tmp) the ansible script errors due to the requested handler not being present


1.1.12 | PATCH | Ensure noexec option set on /var/tmp partition
`ERROR! The requested handler 'remount var_tmp' was not found in either the main handlers list nor in the listening handlers list`

1.1.18 | PATCH | Ensure nodev option set on /home partition
`ERROR! The requested handler 'remount home' was not found in either the main handlers list nor in the listening handlers list`

**Overall Review of Changes:**
I have added the handlers to pass this section of the CIS benchmark if partitions have been configured for these directories


**How has this been tested?:**
Tested on Amazon Linux 2 with partitions created via LVM