### PR TITLE
Fix bootloader path on EFI images

### DIFF
--- a/tasks/prelim.yml
+++ b/tasks/prelim.yml
@@ -35,21 +35,13 @@
 
 - name: set bootloader type
   block:
-      - name: "PRELIM | set fact if UEFI boot | RHEL or OEL"
-        set_fact:
-            amazon2cis_bootloader_file: /boot/efi/EFI/redhat/grub.cfg
-            amazon2cis_legacy_boot: false
-        when:
-            - amazon2cis_efi_boot.stat.exists
-            - ansible_distribution != 'CentOS'  # Note: rhel & OEL both use redhat path
-
       - name: "PRELIM | set fact if UEFI boot | Amazon Linux 2 "
         set_fact:
             amazon2cis_bootloader_file: /boot/efi/EFI/amzn/grub.cfg
             amazon2cis_legacy_boot: false
         when:
             - amazon2cis_efi_boot.stat.exists
-            - ansible_distribution == 'CentOS'
+            - ansible_distribution == 'Amazon'
 
       - name: "PRELIM | set if not UEFI boot"
         set_fact:


### PR DESCRIPTION
Changed the ansible_distribution variable to Amazon instead of CentOS and removed checking bootloader path of other than CentOS systems.

**Overall Review of Changes:**
A general description of the changes made that are being requested for merge

**Issue Fixes:**
Please list (using linking) any open issues this PR addresses

**Enhancements:**
Please list any enhancements/features that are not open issue tickets

**How has this been tested?:**
Please give an overview of how these changes were tested. If they were not please use N/A

Signed-off-by: Navneet Singh <navneet.singh2012@gmail.com>