### PR TITLE
Correct 4.1.15 sudo audit syntax

### DIFF
--- a/templates/audit/99_auditd.rules.j2
+++ b/templates/audit/99_auditd.rules.j2
@@ -66,8 +66,8 @@
 -w /etc/sudoers.d/ -p wa -k scope
 {% endif %}
 {% if amazon2cis_rule_4_1_15 %}
--a exit,always -F arch=b64 -C euid!=uid -F euid=0 -Fauid>=1000 -F auid!=4294967295 -S execve -k actions
--a exit,always -F arch=b32 -C euid!=uid -F euid=0 -Fauid>=1000 -F auid!=4294967295 -S execve -k actions
+-a always,exit -F arch=b64 -C euid!=uid -F euid=0 -F auid>=1000 -F auid!=4294967295 -S execve -k actions
+-a always,exit -F arch=b32 -C euid!=uid -F euid=0 -F auid>=1000 -F auid!=4294967295 -S execve -k actions
 {% endif %}
 {% if amazon2cis_rule_4_1_16 %}
 -w /sbin/insmod -p x -k modules


### PR DESCRIPTION
**Overall Review of Changes:**
The correct syntax for auditd rules is -a action,filter.

The CIS Benchmark is inconsistent on this between remediation and verification on 32 vs 64 bit and the -F typo appears to have come from a line wrap issue with the CIS Benchmark example.

The rest of this same file uses `-a always,exit` except these two lines, and the AMAZON2-CIS-Audit tests also check for the correct `-a always,exit`
https://github.com/ansible-lockdown/AMAZON2-CIS-Audit/blob/devel/section_4/cis_4.1/cis_4.1.15.yml
I also found this discussion from 2014 about the ordering:
https://listman.redhat.com/archives/linux-audit/2014-April/009031.html

**How has this been tested?:**
We have run it against an Amazon Linux 2 EC2 instance and then ran the AMAZON2-CIS-Audit repo tests against it.
