### PR TITLE
removed legacy references to 6.2.12-17 issue #43

### DIFF
--- a/templates/ansible_vars_goss.yml.j2
+++ b/templates/ansible_vars_goss.yml.j2
@@ -404,7 +404,6 @@ amazon2cis_rule_5_2_4_10: {{ amazon2cis_rule_5_2_4_10 }}
 amazon2cis_rule_5_3_1: {{ amazon2cis_rule_5_3_1 }}
 amazon2cis_rule_5_3_2: {{ amazon2cis_rule_5_3_2 }}
 
-
 # Section 6
 amazon2cis_rule_6_1_1: {{ amazon2cis_rule_6_1_1 }}
 amazon2cis_rule_6_1_2: {{ amazon2cis_rule_6_1_2 }}
@@ -432,13 +431,6 @@ amazon2cis_rule_6_2_8: {{ amazon2cis_rule_6_2_8 }}
 amazon2cis_rule_6_2_9: {{ amazon2cis_rule_6_2_9 }}
 amazon2cis_rule_6_2_10: {{ amazon2cis_rule_6_2_10 }}
 amazon2cis_rule_6_2_11: {{ amazon2cis_rule_6_2_11 }}
-amazon2cis_rule_6_2_12: {{ amazon2cis_rule_6_2_12 }}
-amazon2cis_rule_6_2_13: {{ amazon2cis_rule_6_2_13 }}
-amazon2cis_rule_6_2_14: {{ amazon2cis_rule_6_2_14 }}
-amazon2cis_rule_6_2_15: {{ amazon2cis_rule_6_2_15 }}
-amazon2cis_rule_6_2_16: {{ amazon2cis_rule_6_2_16 }}
-amazon2cis_rule_6_2_17: {{ amazon2cis_rule_6_2_17 }}
-
 
 ####
 ## Section 1


### PR DESCRIPTION
**Overall Review of Changes:**
Remeved references to 6.2.12-17 as not required they don't exist in v3.0.0

**Issue Fixes:**
thanks to @gocyclones
#43 

**How has this been tested?:**
Pipeline

