### PR TITLE
Container correctness

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: Systemd restart tmp.mount
+  when: not system_is_container
   ansible.builtin.systemd:
     name: tmp.mount
     daemon_reload: true
@@ -44,19 +45,23 @@
     state: remounted
 
 - name: Systemd_daemon_reload
+  when: not system_is_container
   ansible.builtin.systemd:
     daemon_reload: true
 
 - name: Rebuild_grub
+  when: not system_is_container
   ansible.builtin.command: /sbin/grub2-mkconfig -o "{{ amazon2cis_bootloader_file }}"
   changed_when: true
 
 - name: Restart_postfix
+  when: not system_is_container
   ansible.builtin.service:
     name: postfix
     state: restarted
 
 - name: Sysctl_flush_ipv4_routes
+  when: not system_is_container
   ansible.posix.sysctl:
     name: net.ipv4.route.flush
     value: '1'
@@ -64,6 +69,7 @@
   ignore_errors: true # noqa ignore-errors
 
 - name: Sysctl_flush_ipv6_routes
+  when: not system_is_container
   ansible.posix.sysctl:
     name: net.ipv6.route.flush
     value: '1'
@@ -71,16 +77,19 @@
   ignore_errors: true # noqa ignore-errors
 
 - name: Restart_rsyslog
+  when: not system_is_container
   ansible.builtin.service:
     name: rsyslog
     state: restarted
 
 - name: Restart_journald
+  when: not system_is_container
   ansible.builtin.service:
     name: systemd-journald
     state: restarted
 
 - name: Restart_systemd_journal_upload
+  when: not system_is_container
   ansible.builtin.service:
     name: systemd-journal-upload
     state: restarted
@@ -99,10 +108,12 @@
   register: discovered_augenrule_load
 
 - name: Restart_auditd # noqa: command-instead-of-module
+  when: not system_is_container
   ansible.builtin.command: /sbin/service auditd restart
   changed_when: true
 
 - name: Restart sshd
+  when: not system_is_container
   ansible.builtin.service:
     name: sshd
     state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,6 +15,25 @@
     fail_msg: "You must use Ansible {{ min_ansible_version }} or greater"
     success_msg: "This role is running a supported version of ansible {{ ansible_version.full }} >= {{ min_ansible_version }}"
 
+- name: "Setup rules if container"
+  when: ansible_connection == 'docker' or ansible_facts.virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]
+  tags:
+    - container_discovery
+    - always
+  block:
+    - name: "Discover and set container variable if required"
+      ansible.builtin.set_fact:
+        system_is_container: true
+
+    - name: "Load variable for container"
+      ansible.builtin.include_vars:
+        file: "{{ container_vars_file }}"
+
+    - name: "Output if discovered is a container"
+      when: system_is_container
+      ansible.builtin.debug:
+        msg: system has been discovered as a container
+
 - name: Ensure root password is set
   when: amazon2cis_rule_4_5_2_4
   tags: always

--- a/tasks/section_1/cis_1.1.1.x.yml
+++ b/tasks/section_1/cis_1.1.1.x.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "1.1.1.1 | PATCH | Ensure cramfs kernel module is not available"
-  when: amazon2cis_rule_1_1_1_1
+  when:
+    - amazon2cis_rule_1_1_1_1
+    - not system_is_container
   tags:
     - level1
     - automated
@@ -33,7 +35,9 @@
         state: absent
 
 - name: "1.1.1.2 | PATCH | Ensure freevxfs kernel module is not available"
-  when: amazon2cis_rule_1_1_1_2
+  when:
+    - amazon2cis_rule_1_1_1_2
+    - not system_is_container
   tags:
     - level1
     - automated
@@ -65,7 +69,9 @@
         state: absent
 
 - name: "1.1.1.3 | PATCH | Ensure hfs kernel module is not available"
-  when: amazon2cis_rule_1_1_1_3
+  when:
+    - amazon2cis_rule_1_1_1_3
+    - not system_is_container
   tags:
     - level1
     - automated
@@ -97,7 +103,9 @@
         state: absent
 
 - name: "1.1.1.4 | PATCH | Ensure hfsplus kernel module is not available"
-  when: amazon2cis_rule_1_1_1_4
+  when:
+    - amazon2cis_rule_1_1_1_4
+    - not system_is_container
   tags:
     - level1
     - automated
@@ -129,7 +137,9 @@
         state: absent
 
 - name: "1.1.1.5 | PATCH | Ensure jffs2 kernel module is not available"
-  when: amazon2cis_rule_1_1_1_5
+  when:
+    - amazon2cis_rule_1_1_1_5
+    - not system_is_container
   tags:
     - level1
     - automated
@@ -161,7 +171,9 @@
         state: absent
 
 - name: "1.1.1.6 | PATCH | Ensure squashfs kernel module is not available"
-  when: amazon2cis_rule_1_1_1_6
+  when:
+    - amazon2cis_rule_1_1_1_6
+    - not system_is_container
   tags:
     - level2
     - automated
@@ -193,7 +205,9 @@
         state: absent
 
 - name: "1.1.1.7 | PATCH | Ensure udf kernel module is not available"
-  when: amazon2cis_rule_1_1_1_7
+  when:
+    - amazon2cis_rule_1_1_1_7
+    - not system_is_container
   tags:
     - level2
     - automated
@@ -225,7 +239,9 @@
         state: absent
 
 - name: "1.1.1.8 | PATCH | Ensure usb-storage kernel module is not available"
-  when: amazon2cis_rule_1_1_1_8
+  when:
+    - amazon2cis_rule_1_1_1_8
+    - not system_is_container
   tags:
     - level1
     - automated

--- a/tasks/section_1/cis_1.3.x.yml
+++ b/tasks/section_1/cis_1.3.x.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "1.3.1 | PATCH | Ensure authentication required for single user mode"
-  when: amazon2cis_rule_1_3_1
+  when:
+    - amazon2cis_rule_1_3_1
+    - not system_is_container
   tags:
     - level1
     - automated

--- a/tasks/section_1/cis_1.4.x.yml
+++ b/tasks/section_1/cis_1.4.x.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "1.4.1 | PATCH | Ensure address space layout randomization (ASLR) is enabled"
-  when: amazon2cis_rule_1_4_1
+  when:
+    - amazon2cis_rule_1_4_1
+    - not system_is_container
   tags:
     - level1
     - automated
@@ -18,7 +20,9 @@
     sysctl_file: "{{ kernel_sysctl_file }}"
 
 - name: "1.4.2 | PATCH | Ensure ptrace_scope is restricted"
-  when: amazon2cis_rule_1_4_2
+  when:
+    - amazon2cis_rule_1_4_2
+    - not system_is_container
   tags:
     - level1
     - automated

--- a/tasks/section_2/cis_2.1.x.yml
+++ b/tasks/section_2/cis_2.1.x.yml
@@ -1,7 +1,9 @@
 ---
 
 - name: "2.1.1 | PATCH | Ensure time synchronization is in use"
-  when: amazon2cis_rule_2_1_1
+  when:
+    - amazon2cis_rule_2_1_1
+    - not system_is_container
   tags:
     - level1
     - automated

--- a/tasks/section_2/cis_2.2.x.yml
+++ b/tasks/section_2/cis_2.2.x.yml
@@ -647,6 +647,7 @@
   when:
     - not amazon2cis_is_mail_server
     - amazon2cis_rule_2_2_21
+    - not system_is_container
   tags:
     - level1-server
     - level1-workstation

--- a/tasks/section_5/cis_5.3.x.yml
+++ b/tasks/section_5/cis_5.3.x.yml
@@ -40,6 +40,7 @@
     - amazon2cis_rule_5_3_2
     - amazon2cis_config_aide
     - not system_is_ec2
+    - not system_is_container
   tags:
     - level1-server
     - level1-workstation

--- a/vars/is_container.yml
+++ b/vars/is_container.yml
@@ -1,0 +1,148 @@
+---
+
+# File to skip controls if container
+# Based on standard image no changes
+# it expected all pkgs required for the container are already installed
+
+## controls
+
+# Firewall
+amazon2cis_firewalld: none
+
+# SElinux
+amazon2cis_selinux_disable: true
+
+## Related individual rules
+
+# kernel sysctls (read-only /proc/sys/kernel)
+amazon2cis_rule_1_4_1: false
+amazon2cis_rule_1_4_2: false
+
+# kernel filesystem modules
+amazon2cis_rule_1_1_1_1: false
+amazon2cis_rule_1_1_1_2: false
+amazon2cis_rule_1_1_1_3: false
+amazon2cis_rule_1_1_1_4: false
+amazon2cis_rule_1_1_1_5: false
+amazon2cis_rule_1_1_1_6: false
+amazon2cis_rule_1_1_1_7: false
+amazon2cis_rule_1_1_1_8: false
+
+# single-user mode
+amazon2cis_rule_1_3_1: false
+
+# time sync
+amazon2cis_rule_2_1_1: false
+amazon2cis_rule_2_1_3: false
+
+# MTA
+amazon2cis_rule_2_2_21: false
+
+# AIDE schedule
+amazon2cis_rule_5_3_2: false
+
+# Firewall sub-section imports (3.4.2/3/4)
+amazon2cis_system_firewall: none
+
+# root profile / password
+amazon2cis_rule_4_5_2_2: false
+amazon2cis_rule_4_5_2_4: false
+
+# 3.3.x network sysctls (read-only /proc/sys/net)
+amazon2cis_rule_3_3_1: false
+amazon2cis_rule_3_3_2: false
+amazon2cis_rule_3_3_3: false
+amazon2cis_rule_3_3_4: false
+amazon2cis_rule_3_3_5: false
+amazon2cis_rule_3_3_6: false
+amazon2cis_rule_3_3_7: false
+amazon2cis_rule_3_3_8: false
+amazon2cis_rule_3_3_9: false
+amazon2cis_rule_3_3_10: false
+amazon2cis_rule_3_3_11: false
+
+# firewall service start
+amazon2cis_rule_3_4_1_2: false
+
+# cron / anacron
+amazon2cis_rule_4_1_1_1: false
+amazon2cis_rule_4_1_1_2: false
+amazon2cis_rule_4_1_1_3: false
+amazon2cis_rule_4_1_1_4: false
+amazon2cis_rule_4_1_1_5: false
+amazon2cis_rule_4_1_1_6: false
+amazon2cis_rule_4_1_1_7: false
+amazon2cis_rule_4_1_1_8: false
+amazon2cis_rule_4_1_2_1: false
+
+# sshd
+amazon2cis_rule_4_2_1: false
+amazon2cis_rule_4_2_2: false
+amazon2cis_rule_4_2_3: false
+amazon2cis_rule_4_2_4: false
+amazon2cis_rule_4_2_5: false
+amazon2cis_rule_4_2_6: false
+amazon2cis_rule_4_2_7: false
+amazon2cis_rule_4_2_8: false
+amazon2cis_rule_4_2_9: false
+amazon2cis_rule_4_2_10: false
+amazon2cis_rule_4_2_11: false
+amazon2cis_rule_4_2_12: false
+amazon2cis_rule_4_2_13: false
+amazon2cis_rule_4_2_14: false
+amazon2cis_rule_4_2_15: false
+amazon2cis_rule_4_2_16: false
+amazon2cis_rule_4_2_17: false
+amazon2cis_rule_4_2_18: false
+amazon2cis_rule_4_2_19: false
+amazon2cis_rule_4_2_20: false
+amazon2cis_rule_4_2_21: false
+amazon2cis_rule_4_2_22: false
+
+# 5.2.1.x auditd service
+amazon2cis_rule_5_2_1_1: false
+amazon2cis_rule_5_2_1_2: false
+amazon2cis_rule_5_2_1_3: false
+amazon2cis_rule_5_2_1_4: false
+
+# 5.2.2.x audit data retention
+amazon2cis_rule_5_2_2_1: false
+amazon2cis_rule_5_2_2_2: false
+amazon2cis_rule_5_2_2_3: false
+amazon2cis_rule_5_2_2_4: false
+
+# 5.2.3.x audit rules
+amazon2cis_rule_5_2_3_1: false
+amazon2cis_rule_5_2_3_2: false
+amazon2cis_rule_5_2_3_3: false
+amazon2cis_rule_5_2_3_4: false
+amazon2cis_rule_5_2_3_5: false
+amazon2cis_rule_5_2_3_6: false
+amazon2cis_rule_5_2_3_7: false
+amazon2cis_rule_5_2_3_8: false
+amazon2cis_rule_5_2_3_9: false
+amazon2cis_rule_5_2_3_10: false
+amazon2cis_rule_5_2_3_11: false
+amazon2cis_rule_5_2_3_12: false
+amazon2cis_rule_5_2_3_13: false
+amazon2cis_rule_5_2_3_14: false
+amazon2cis_rule_5_2_3_15: false
+amazon2cis_rule_5_2_3_16: false
+amazon2cis_rule_5_2_3_17: false
+amazon2cis_rule_5_2_3_18: false
+amazon2cis_rule_5_2_3_19: false
+amazon2cis_rule_5_2_3_20: false
+amazon2cis_rule_5_2_3_21: false
+
+# 5.2.4.x audit log file perms
+amazon2cis_rule_5_2_4_1: false
+amazon2cis_rule_5_2_4_2: false
+amazon2cis_rule_5_2_4_3: false
+amazon2cis_rule_5_2_4_4: false
+amazon2cis_rule_5_2_4_5: false
+amazon2cis_rule_5_2_4_6: false
+amazon2cis_rule_5_2_4_7: false
+amazon2cis_rule_5_2_4_8: false
+amazon2cis_rule_5_2_4_9: false
+amazon2cis_rule_5_2_4_10: false
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -12,6 +12,11 @@ update_audit_template: false
 # system_is_container to true. Otherwise, the default value
 # 'false' is left unchanged.
 system_is_container: false
+# The filename of the existing yml file in role's 'vars/' sub-directory
+# to be used for managing the role-behavior when a container was detected:
+# (de)activating rules or for other tasks (e.g. disabling Selinux or a specific
+# firewall-type).
+container_vars_file: is_container.yml
 
 # Used to control warning summary
 warn_control_list: ""


### PR DESCRIPTION
# PR Summary

Adds container-awareness to the Amazon Linux 2 CIS role so it can be safely applied to container images without failing on rules that depend on host-only kernel/systemd interfaces. Auto-detects containers via `ansible_facts.virtualization_type` (or `ansible_connection == 'docker'`), sets `system_is_container: true`, and loads `vars/is_container.yml` to disable rules that cannot succeed inside an unprivileged container. Also gates `handlers/main.yml` services and a handful of in-task `when:` clauses on `not system_is_container` so that triggered restarts and container-incompatible tasks are skipped consistently.

## Compliance with CONTRIBUTING.rst

- Work is on a feature branch (`container-correctness`) targeted at `devel`.
- Commits are signed off (DCO) and GPG-signed per repo policy.

## Files touched

- `tasks/main.yml` — container-discovery block (tagged `always`, `container_discovery`).
- `vars/main.yml` — adds `container_vars_file` pointer.
- `vars/is_container.yml` — new; rule toggles for container runs.
- `handlers/main.yml` — guards systemd/service/sysctl/grub handlers.
- `tasks/section_1/cis_1.1.1.x.yml`, `1.3.x`, `1.4.x`, `section_2/cis_2.1.x`, `2.2.x`, `section_5/cis_5.3.x` — adds `not system_is_container` guards on container-incompatible tasks.

## Justifications for rules disabled in containers

**Kernel filesystem modules (1.1.1.1–1.1.1.8: cramfs, freevxfs, hfs, hfsplus, jffs2, squashfs, udf, usb-storage)** — Containers share the host kernel and cannot load/unload modules or write to `/etc/modprobe.d` in any meaningful way; module state is a host concern, not a container one.

**1.3.1 single-user mode authentication** — Containers do not boot into runlevels and have no rescue/single-user target; the control is meaningless.

**1.4.1 ASLR / 1.4.2 ptrace_scope** — These are kernel sysctls under `/proc/sys/kernel`; in a non-privileged container they are read-only and inherited from the host, so attempting to set them fails.

**2.1.1 / 2.1.3 time synchronization** — Container clocks come from the host kernel; running chrony/ntp inside a container is unsupported and conflicts with the host time source.

**2.2.21 MTA local-only** — Container images are not expected to run postfix; the MTA control assumes a long-running mail daemon.

**3.3.1–3.3.11 network sysctls** — Same root cause as 1.4.x: `/proc/sys/net/*` is namespaced/read-only inside unprivileged containers and is owned by the host or the orchestrator's network plugin.

**3.4.1.2 / `amazon2cis_firewall: none` / `amazon2cis_firewalld: none`** — iptables/firewalld inside a container conflicts with host networking and Docker/Podman-managed iptables chains; firewalling is the orchestrator's responsibility.

**4.1.1.1–4.1.1.8, 4.1.2.1 cron/anacron** — Containers should run a single foreground process; cron is not expected and the packages typically aren't installed in minimal base images.

**4.2.1–4.2.22 sshd** — Containers should not expose sshd; remote access is via `docker exec`/`kubectl exec`. Hardening a non-existent daemon produces failures or false positives.

**4.5.2.2 / 4.5.2.4 root password & profile** — Container root accounts are managed by the image build; setting/locking root password at runtime breaks `USER 0` semantics and is generally pointless in an ephemeral filesystem.

**5.2.1.x–5.2.4.x auditd** — The Linux audit subsystem is host-kernel scoped and cannot be enabled per-container; running auditd inside a container either fails or silently does nothing, so service/rule/log-permission controls are not applicable.

**5.3.2 AIDE scheduling** — AIDE database integrity scans on an immutable, ephemeral container filesystem are not meaningful; the host or image build pipeline is the right place for image integrity.

**SELinux (`amazon2cis_selinux_disable: true`)** — SELinux mode is set on the host kernel; the container inherits it and cannot toggle it. Setting `disable: true` here just stops the role from attempting host-level SELinux changes from inside a container.
